### PR TITLE
Update paper.md by fixing spacing in R output

### DIFF
--- a/JOSS-paper/paper.md
+++ b/JOSS-paper/paper.md
@@ -225,7 +225,8 @@ after performing the above logistic regression:
 
 ```
 Call:
-glm(formula = as.vector(pix_matrix) ~ as.vector(dist), family = binomial(link = logit))
+glm(formula = as.vector(pix_matrix) ~ as.vector(dist), 
+family = binomial(link = logit))
 
 Deviance Residuals:
     Min       1Q   Median       3Q      Max


### PR DESCRIPTION
I added a carriage return in the first line of the R output. 

Previously, in the pdf, the R output wasn't "wrapped", so some of it was not displayed properly. I *think* that this will fix the issue. 